### PR TITLE
Error fix: (Can't find any repo with the name {epitome} for BitBucket in your config file.)

### DIFF
--- a/ftpbucket/BBjson.php
+++ b/ftpbucket/BBjson.php
@@ -49,7 +49,7 @@ class BBjson
         // --- Checks if the repo from BB match one of yours --- //
         // Loop through configs and find a matching one
         foreach ( $config['repos'] as $repo ) {
-            if ( strpos($payload_repo_name, $repo['repo_name']) != false && $repo['repo_host'] == 'bitbucket' ) {
+            if ( strpos($payload_repo_name, $repo['repo_name']) !== false && $repo['repo_host'] == 'bitbucket' ) {
                 $this->config->ftp = $repo;
                 $check++;
             }


### PR DESCRIPTION
- Enabled 'strict matching' i.e changed != to !==

- If the library user has their 'bitbucket' 'root_name'
similar to their 'repo_name', str_pos() will return 0
as the first occurrence position.

- Without strict matching

echo strpos("epitome/epitome", "epitome") != false ? "TRUE" : "FALSE";

will evaluate to "FALSE".  

Which is buggy. Hence receiving the error
(Can't find any repo with the name {epitome} for BitBucket in your config file.)

- Strict matching solves the silent bug.
