### PR TITLE
401 Unauthorized error returned when retrieving files or directory contents using Bitbucket's app password.

### DIFF
--- a/ftpbucket/BBjson.php
+++ b/ftpbucket/BBjson.php
@@ -194,7 +194,7 @@ class BBjson
                     }
 
                     // Todo http://arguments.callee.info/2010/02/21/multiple-curl-requests-with-php/
-                    $url = $file['new']['links']['self']['href'];
+                    $url = fix_bitbucket_api_base_url($file['new']['links']['self']['href']);
 
                     $cu = curl_init ( $url ); 
                     curl_setopt ( $cu, CURLOPT_USERPWD, $this->config->auth['username'] . ':' . $this->config->auth['password'] ); 
@@ -236,6 +236,14 @@ class BBjson
         }
     }
 
+    private function fix_bitbucket_api_base_url($url)
+    {
+        if (!preg_match("/^https:\/\/bitbucket.org\/!api/", $url)) {
+            return $url;
+        }
+
+        return str_replace("https://bitbucket.org/!api", "https://bitbucket.org/api", $url);
+    }
 
     private function api_get_values ( $url, $branch ) {
 


### PR DESCRIPTION


Description:
===

- When this library tries to access the updated file contents on [line 197](https://github.com/Wanchai/FTPbucket/blob/b4fe4d75b79bb1a206c84261e28ada3c41092f13/ftpbucket/BBjson.php#L197) using [Bitbucket's API endpoint](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#api-repositories-workspace-repo-slug-src-commit-path-get), a 401 Unauthorized error is returned.

Notes:
===

1. This only happens when using [Bitbucket's app password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) with Basic authentication even when you've granted it all OAuth scopes/permissions.

2. On the contrary, no issues are experienced if you use your main Bitbucket login account password. Keep in mind that using the main Atlassian account password has been [deprecated in favor of "app passwords"](https://bitbucket.org/blog/deprecating-atlassian-account-password-for-bitbucket-api-and-git-activity?utm_source=alert-email&utm_medium=email&utm_campaign=bb-login-deprecation_EML-11685&jobid=105243826&subid=1536431921).

Solution:
===

I managed to resolve this issue by removing the "!" sign from the endpoint routes.
https://bitbucket.org/!api/2.0/repositories/test7_wanchai/test-indent/src/2e39c147293f02648190ad62f64cb6e443f6bd6a/dummy-1000.txt

Steps to reproduce the issue:
===

1. [Create an app password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) and give it the relevant "OAuth scopes/permissions". I granted mine to have ("pipeline", "webhook" & "repository"). On save, copy the auto-generated app password.

2. Try accessing the [endpoint to retrieve a file on your remote Bitbucket repository](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#api-repositories-workspace-repo-slug-src-commit-path-get) using Basic authentication with the "app password" and your "username".

3. Here is a script to list all recently committed files in my test repo. [List of updated committed files wanchai-ftpbucket](https://gist.github.com/steven7mwesigwa/9d638fb98f294b35b1f3f1159c7af75c).

4. Here is a script that tries accessing one of my file contents. It will throw a "401 Unauthorized error". [401 Unauthorized wanchai-ftpbucket](https://gist.github.com/steven7mwesigwa/c0bd9a5624349ac7d25d22c866ab3ace).

5. To resolve the error, remove the "!" sign from Line 6 (CURL URL) and run the script again. https://gist.github.com/steven7mwesigwa/c0bd9a5624349ac7d25d22c866ab3ace#file-401-unauthorized-wanchai-ftpbucket-L6